### PR TITLE
feat: api以下のrouteを/apiで読み込むようにする、ついでにimportの*をやめて必要なものだけimportするようにする

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from .models import *
+from .models import Threads
 
 
 class ThreadSerializer(serializers.ModelSerializer):

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 from rest_framework import routers
-from .views import *
+from . import views
 
 router = routers.DefaultRouter()
-router.register(r"threads", ThreadAPIView)
+router.register(r"threads", views.ThreadAPIView, basename="thread-list")

--- a/api/views.py
+++ b/api/views.py
@@ -1,7 +1,7 @@
 from django.shortcuts import render
 from rest_framework import viewsets
-from .models import *
-from .serializers import *
+from .models import Threads
+from .serializers import ThreadSerializer
 
 # Create your views here.
 

--- a/config/urls.py
+++ b/config/urls.py
@@ -20,5 +20,5 @@ from api.urls import router as api_router
 
 urlpatterns = [
     path("admin/", admin.site.urls),
-    path("threads/", include(api_router.urls)),
+    path("api/", include(api_router.urls)),
 ]


### PR DESCRIPTION
## やったこと

- json形式のレスポンスを返せるようにした
- api以下のrouteを/apiで読み込めるようにした
- フロントエンドからリクエストを投げればそれっぽくなりそう

related issue: xxx

## 動作確認結果

<img width="1235" alt="Thread_Api_List_–_Django_REST_framework" src="https://github.com/morieeeenyo/django-chat-gpt-app/assets/64336740/bb3ffdd4-10f9-4644-8c89-6ea603b70b0d">

## 補足